### PR TITLE
Dashboard Standings Endpoint

### DIFF
--- a/backend/controllers/dasboard.controller.js
+++ b/backend/controllers/dasboard.controller.js
@@ -1,0 +1,29 @@
+const Dashboard = require("../models/dashboard.model");
+
+module.exports = {
+  getStandings: async (req, res, next) => {
+    try {
+      const { userid, week } = req.params;
+      console.log(userid, week);
+      const result = await Dashboard.getStandings(userid, week);
+      res.send(result);
+      console.log(result);
+    } catch (error) {
+      next(error);
+    }
+  },
+};
+
+// const testGetStandings = async () => {
+//   try {
+//     const userid = 5;
+//     const week = 10;
+//     const result = await Dashboard.getStandings(userid, week);
+//     console.log(result);
+//   } catch (error) {
+//     console.error(error);
+//   }
+// };
+
+// // Call the asynchronous function
+// testGetStandings();

--- a/backend/controllers/leagues.controller.js
+++ b/backend/controllers/leagues.controller.js
@@ -16,11 +16,14 @@ module.exports = {
       const { league_name, league_owner } = req.body;
       const result = await League.make(league_name, league_owner);
       res.send(result);
-    } catch (error) {}
+    } catch (error) {
+      next(error);
+    }
   },
   addUser: async (req, res, next) => {
     try {
       console.log(req.body);
+      console.log("addUser");
       const { league_name, user_id, league_id } = req.body;
       const result = await League.join(league_name, user_id, league_id);
       res.send(result);

--- a/backend/models/dashboard.model.js
+++ b/backend/models/dashboard.model.js
@@ -1,0 +1,41 @@
+const pool = require("./db");
+
+exports.getStandings = async (user_id, week_number) => {
+  try {
+    const [leagueIds] = await pool.query(
+      `
+        SELECT 
+        league_id,
+        league_name
+      FROM league_users
+      WHERE user_id = ?;
+        `,
+      [user_id]
+    );
+    console.log(leagueIds);
+    const leagueStandings = await Promise.all(
+      leagueIds.map(async (league) => {
+        const [standings] = await pool.query(
+          `
+          SELECT
+          u.user_name,
+          l.user_id,
+          SUM(p.correct_pick) AS total_correct_picks
+      FROM league_users l
+      JOIN picks p ON p.user_id = l.user_id
+      JOIN users u ON u.user_id = l.user_id
+      WHERE l.league_id = ? AND p.week_number = ?
+      GROUP BY l.user_id, u.user_name
+      order by total_correct_picks DESC;
+      `,
+          [league.league_id, week_number]
+        );
+        return { [league.league_name]: standings };
+      })
+    );
+    return leagueStandings;
+  } catch (error) {
+    console.error("Error in getStandings:", error);
+    throw error;
+  }
+};

--- a/backend/models/leagues.model.js
+++ b/backend/models/leagues.model.js
@@ -36,6 +36,7 @@ exports.make = async (league_name, league_owner) => {
 };
 // TODO: return error if user has already joined league.
 exports.join = async (league_name, user_id, league_id) => {
+  console.log("user", user_id);
   try {
     const member = await pool.query(
       `

--- a/backend/routes/dashboard.routes.js
+++ b/backend/routes/dashboard.routes.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const router = express.Router();
+const dashboardController = require("../controllers/dasboard.controller");
+
+router.get("/");
+router.get("/:userid/getStandings/:week", dashboardController.getStandings);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ const app = express();
 const matchesRoutes = require("./routes/matches.routes");
 const userRoutes = require("./routes/user.routes");
 const leaguesRoutes = require("./routes/leagues.routes");
+const dashboardRoutes = require("./routes/dashboard.routes");
 
 app.use(cors());
 app.use(bodyparser.json());
@@ -19,6 +20,7 @@ app.use(bodyparser.urlencoded({ extended: true }));
 app.use("/matches", matchesRoutes);
 app.use("/users", userRoutes);
 app.use("/leagues", leaguesRoutes);
+app.use("/dashboard", dashboardRoutes);
 
 app.use(errorHandler);
 

--- a/frontend/src/components/League.jsx
+++ b/frontend/src/components/League.jsx
@@ -6,7 +6,8 @@ import { useEffect, useState } from "react";
 
 export default function League() {
   const [leagues, setLeagues] = useState([])
-  const {userId} = useParams()
+  const {userid} = useParams()
+  console.log(userid)
   useEffect (() =>  {
     const fetchData = async () => {   
     try {
@@ -23,11 +24,13 @@ export default function League() {
 
   const handleJoinLeague = (league_name, league_id, user) => {
     //guard for empty data in joining league. 
+    console.log(user)
     const userData = {
       league_name:league_name,
       league_id:league_id,
       user_id: user
     }
+    console.log(userData)
     axios.post('http://localhost:8080/leagues/addUser', userData).then((res) => {
       console.log(res.status, res.data)
     })
@@ -79,8 +82,9 @@ export default function League() {
         gap={3}
         justifyContent={'space-between'}
         >
-        <Button size={['sm', 'md']}  onClick={()=> handleJoinLeague(league.league_name, league.league_id, userId)} colorScheme="blue">Join</Button>
-        <Button size={['sm', 'md']} variant={'outline'}  onClick={()=> handleLeaveLeague(league.league_name, league.league_id, userId)} colorScheme="red">X</Button>
+        <Button size={['sm', 'md']}  onClick={()=> handleJoinLeague(league.league_name, league.league_id, userid)} colorScheme="blue">Join</Button>
+
+        <Button size={['sm', 'md']} variant={'outline'}  onClick={()=> handleLeaveLeague(league.league_name, league.league_id, userid)} colorScheme="red">X</Button>
         </Flex>
         
       </Flex>

--- a/frontend/src/components/Picks.jsx
+++ b/frontend/src/components/Picks.jsx
@@ -3,7 +3,9 @@ import { useParams } from "react-router-dom";
 import Pick from "./PickCard";
 import { useEffect, useState } from "react";
 import axios from 'axios'
-const Picks = () => {
+
+
+const Picks = ({}) => {
 const { userid, week } = useParams()
   const [games, setGames] = useState([])
   
@@ -24,6 +26,7 @@ const { userid, week } = useParams()
     flexWrap={'wrap'}
     gap={3}
     >
+       
         {games.map((game, index) => (
           <Flex key={index} 
           w={['100%','222px']}
@@ -38,9 +41,12 @@ const { userid, week } = useParams()
             spread={game.point_spread}
             userPick={game.user_pick}
           />
+          
            </Flex>
         ))}
+       
     </Flex>
+
   ); 
 };
 

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
+import {Flex} from '@chakra-ui/react'
 import axios from 'axios'
 import { useParams } from "react-router-dom";
+import Standings from "./Standings";
 
 const Profile = () => {
   const {userid} = useParams()
@@ -17,8 +19,10 @@ const Profile = () => {
     fetchData()
   },[])
 
-  console.log(userid)
-  return <div>Profile</div>;
+  
+  return <Flex>
+      <Standings userid={userid} />
+  </Flex>
 };
 
 export default Profile

--- a/frontend/src/components/Standings.jsx
+++ b/frontend/src/components/Standings.jsx
@@ -1,0 +1,36 @@
+
+import { Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react'
+import axios from 'axios'
+import { useEffect, useState } from 'react'
+const Standings = ({userid}) => {
+  const [data, setData] = useState(undefined)
+
+    useEffect(()=> {
+      const fetchData = async () => {
+        try {
+          const response = await axios.get('')
+          setData(response.data)
+        } catch (error) {
+          console.error(error)
+        }
+      }
+      fetchData()
+
+    }, [userid])
+    console.log(data)
+  return (
+    <Tabs isFitted variant='line'>
+      <TabList>
+        <Tab>Generic gamers</Tab>
+        <Tab>Polite Pirates</Tab>
+        <Tab>Frought Fidgiters</Tab>
+        <Tab>Placid Pick-makers</Tab>
+      </TabList>
+      <TabPanels>
+
+      </TabPanels>
+    </Tabs>
+  )
+}
+
+export default Standings


### PR DESCRIPTION
    Add express routing to get standings object organized by league.
    queries database for leagues associated with user_id and
    returns them to the client sorted by week standing.